### PR TITLE
2.0.0 Release: Bring config and functionality in line with KIP-310

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,10 @@ Note that standard Kafka parameters can be passed to the internal KafkaConsumer 
   }
 }
 ```
+
+## TODO
+
+* Config Parameters to use source.[config_parameter_name]
+  * Override admin or consumer client by setting source.[admin|consumer].[config_parameter_name]
+* Topics to accept list of strings or list of regexes (or both!)
+* Manually commit offsets to source cluster. These arent used for resuming the mirror process, (tyhe offsets sre stored in the kafka connect offsets store), but are included to allow existing offset monitoring tools to better work.

--- a/README.md
+++ b/README.md
@@ -39,50 +39,51 @@ These are the most common options that are required when configuring this connec
 
 Configuration Parameter | Example | Description
 ----------------------- | ------- | -----------
-**consumer.bootstrap.servers** | source.broker1:9092,source.broker2:9092 | **Mandatory.** Comma separated list of boostrap servers for the source Kafka cluster
-**consumer.auto.offset.reset** | latest | If there is no stored offset for a partition, indicates where to start consuming from. Options are _"earliest"_ or _"latest"_. Default: _earliest_
-**source.topics** | an.interesting.topic,another.topic | Comma separated list of topics to mirror (Note: Cannot be used with _source.topics.regex_)
-**source.topics.regex** | my.topics.* | Java regular expression to match topics to mirror (Note: Cannot be used with _source.topics.regex_)
+**source.bootstrap.servers** | source.broker1:9092,source.broker2:9092 | **Mandatory.** Comma separated list of boostrap servers for the source Kafka cluster
+**source.topic.whitelist** | topic, topic-prefix* | Java regular expression to match topics to mirror. For convenience, comma (',') is interpreted as the regex-choice symbol ('|').
+**source.auto.offset.reset** | earliest | If there is no stored offset for a partition, indicates where to start consuming from. Options are _"earliest"_ or _"latest"_. Default: _earliest_
+**source.group.id** | kafka-connect | Group ID used when writing offsets back to source cluster (for offset lag tracking)
 **destination.topics.prefix** | aggregate. | Prefix to add to source topic names when determining the Kafka topic to publish data to
 
 ## Advanced Options
 
-Some use cases may require modifying the following connector options. Use with care.
+Some use cases may require modifying the following default connector options. Use with care.
 
 Configuration Parameter | Default | Description
 ----------------------- | ------- | -----------
 **include.message.headers** | true | Indicates whether message headers from source records should be included when delivered to the destination cluster.
-**poll.timeout.ms** | 1000 | Maximum amount of time (in milliseconds) the connector will wait in each poll loop without data before returning control to the kafka connect task thread.
-**max.shutdown.wait.ms** | 1500 | Maximum amount of time (in milliseconds) to wait for the connector to gracefully shut down before forcing the consumer and admin clients to close. Note that any values greater than the kafka connect parameter *task.shutdown.graceful.timeout.ms* will not have any effect.
-**consumer.max.poll.records** | 500 | Maximum number of records to return from each poll of the internal KafkaConsumer. When dealing with topics with very large messages, the connector may sometimes spend too long processing each batch of records, causing lag in offset commits, or in serious cases, unnecessary consumer rebalances. Reducing this value can help in these scenarios. Conversely, when processing very small messages, increasing this value may improve overall throughput.
-**partition.monitor.topic.list.timeout.ms** | 60000 | Amount of time (in milliseconds) the partition monitor thread should wait for the source kafka cluster to return topic information before logging a timeout error.
-**partition.monitor.poll.interval.ms** | 300000 | Amount of time (in milliseconds) the partition monitor will wait before re-querying the source cluster for a change in the partitions to be consumed
-**partition.monitor.reconfigure.tasks.on.leader.change** | false | Indicates whether the partition monitor should request a task reconfiguration when partition leaders have changed. In some cases this may be a minor optimization as when generating task configurations, the connector will try to group partitions to be consumed by each task by the leader node. The downside to this is that it may result in additional rebalances.
+**topic.list.timeout.ms** | 60000 | Amount of time (in milliseconds) the partition monitor thread should wait for the source kafka cluster to return topic information before logging a timeout error.
+**topic.list.poll.interval.ms** | 300000 | Amount of time (in milliseconds) the partition monitor will wait before re-querying the source cluster for a change in the topic partitions to be consumed
+**reconfigure.tasks.on.leader.change** | false | Indicates whether the partition monitor should request a task reconfiguration when partition leaders have changed. In some cases this may be a minor optimization as when generating task configurations, the connector will try to group partitions to be consumed by each task by the leader node. The downside to this is that it may result in excessive rebalances.
+**poll.loop.timeout.ms** | 1000 | Maximum amount of time (in milliseconds) the connector will wait in each poll loop without data before returning control to the kafka connect task thread.
+**max.shutdown.wait.ms** | 2000 | Maximum amount of time (in milliseconds) to wait for the connector to gracefully shut down before forcing the consumer and admin clients to close. Note that any values greater than the kafka connect parameter *task.shutdown.graceful.timeout.ms* will not have any effect.
+**source.max.poll.records** | 500 | Maximum number of records to return from each poll of the internal KafkaConsumer. When dealing with topics with very large messages, the connector may sometimes spend too long processing each batch of records, causing lag in offset commits, or in serious cases, unnecessary consumer rebalances. Reducing this value can help in these scenarios. Conversely, when processing very small messages, increasing this value may improve overall throughput.
+**source.key.deserializer** | org.apache.kafka.common.serialization.ByteArrayDeserializer | Key deserializer to use for the kafka consumers connecting to the source cluster.
+**source.value.deserializer** | org.apache.kafka.common.serialization.ByteArrayDeserializer | Value deserializer to use for the kafka consumers connecting to the source cluster.
+**source.enable.auto.commit** | true | If true the consumer's offset will be periodically committed to the source cluster in the background.
+Note that these offsets are not used to resume the connector (They are stored in the Kafka Connect offset store), but may be useful in monitoring the current offset lag of this connector on the source cluster
 
-### Overriding the internal KafkaConsumer Configuration
-Note that standard Kafka parameters can be passed to the internal KafkaConsumer and AdminClient by prefixing the standard consumer configuration parameters with "**consumer.**". This is especially useful in cases where you need to pass authentication parameters to these clients.
+### Overriding the internal KafkaConsumer and AdminClient Configuration
+
+Note that standard Kafka parameters can be passed to the internal KafkaConsumer and AdminClient by prefixing the standard configuration parameters with "*source.*".
+For cases where the configuration for the KafkaConsumer and AdminClient diverges, you can use the more explicit "*connector.consumer.*" and "*connector.admin.*" configuration parameter prefixes to fine tune the settings used for each.
 
 ### Example Configuration
 
 ```javascript
 {
-  "name": "mirrortool-example", // Name of the kafka connect task
+  "name": "kafka-connect-kafka-source-example", // Name of the kafka connect task
     "config": {
-    "tasks.max": "4", // Maximum number of parallel tasks to run
+    "tasks.max": "2", // Maximum number of parallel tasks to run
     "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter", // Set the format of data that is written to kafka. As the connector parses source cluster messages as binary arrays, this will be the usual required value here
     "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter", // Set the format of data that is written to kafka. As the connector parses source cluster messages as binary arrays, this will be the usual required value here
     "connector.class": "com.comcast.kafka.connect.kafka.KafkaSourceConnector", // The full class name of this connector
-    "consumer.bootstrap.servers": "kafka.bootstrap.server1:9092,kafka.bootstrap.server2:9093", // Kafka boostrap servers for source cluster
-    "source.topics": "customer.orders,customer.feedback", // Mirror these two topics from the source cluster
+    "source.bootstrap.servers": "kafka.bootstrap.server1:9092,kafka.bootstrap.server2:9093", // Kafka boostrap servers for source cluster
+    "source.topic.whitelist": "test.topic.*", // Mirror topics matching this regex
+    "source.auto.offset.reset": "earliest", // For partitions without existing offsets stored, start at the tail of the partition
+    "source.group.id": "kafka-connect-testing", // Use this group ID when commiting offsets to the source cluster
     "destination.topics.prefix": "aggregate.", // Add "aggregate." as a prefix to the original topic name when sending to the destination cluster
-    "consumer.auto.offset.reset": "latest", // Start from the latest offsets if no offsets are stored in kafka connect's offset store
+    "connector.consumer.reconnect.backoff.max.ms": "10000" // Override the default consumer setting "reconnect.backoff.max.ms"
   }
 }
 ```
-
-## TODO
-
-* Config Parameters to use source.[config_parameter_name]
-  * Override admin or consumer client by setting source.[admin|consumer].[config_parameter_name]
-* Topics to accept list of strings or list of regexes (or both!)
-* Manually commit offsets to source cluster. These arent used for resuming the mirror process, (tyhe offsets sre stored in the kafka connect offsets store), but are included to allow existing offset monitoring tools to better work.

--- a/build.gradle
+++ b/build.gradle
@@ -16,19 +16,18 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.4'
 }
 
-version = '2.0.0-SNAPSHOT'
+version = '2.0.0'
 
 
 
 dependencies {
-    def kafkaVersion = '1.1.1'
+    def kafkaVersion = '2.0.0'
     def slf4jVersion = '1.7.25'
 
     compile group: 'org.apache.kafka', name: 'connect-api', version: kafkaVersion
     compile group: 'org.apache.kafka', name: 'kafka-clients', version: kafkaVersion
     compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
     compile group: 'org.slf4j', name: 'slf4j-simple', version: slf4jVersion
-
 
     // Test
     def junitVersion = '4.12'
@@ -42,10 +41,7 @@ dependencies {
     testCompile group: 'org.powermock', name: 'powermock-api-easymock', version: powermockVersion
 }
 
-// In this section you declare where to find the dependencies of your project
 repositories {
-    // Use jcenter for resolving your dependencies.
-    // You can declare any Maven/Ivy/file repository here.
     jcenter()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.4'
 }
 
-version = '1.0.0'
+version = '2.0.0-SNAPSHOT'
 
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,27 +9,37 @@
  */
 
 
+
 plugins {
     id 'java'
     id 'idea'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
 }
 
+version = '1.0.0'
+
+
+
 dependencies {
-    compile group: 'org.apache.kafka', name: 'connect-api', version: '1.1.0'
-    compile group: 'org.apache.kafka', name: 'kafka-clients', version: '1.1.0'
+    def kafkaVersion = '1.1.1'
+    def slf4jVersion = '1.7.25'
 
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.6.1'
-    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.1'
+    compile group: 'org.apache.kafka', name: 'connect-api', version: kafkaVersion
+    compile group: 'org.apache.kafka', name: 'kafka-clients', version: kafkaVersion
+    compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
+    compile group: 'org.slf4j', name: 'slf4j-simple', version: slf4jVersion
 
-    // Use JUnit test framework
-    testCompile 'junit:junit:4.12'
 
-    testCompile group: 'org.easymock', name: 'easymock', version: '3.5.1'
-    testCompile group: 'org.powermock', name: 'powermock-core', version: '2.0.0-beta.5'
-    testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.0-beta.5'
-    testCompile group: 'org.powermock', name: 'powermock-api-easymock', version: '2.0.0-beta.5'
+    // Test
+    def junitVersion = '4.12'
+    def easymockVersion = '3.6'
+    def powermockVersion = '2.0.0-beta.5'
 
+    testCompile group: 'junit', name: 'junit', version: junitVersion
+    testCompile group: 'org.easymock', name: 'easymock', version: easymockVersion
+    testCompile group: 'org.powermock', name: 'powermock-core', version: powermockVersion
+    testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: powermockVersion
+    testCompile group: 'org.powermock', name: 'powermock-api-easymock', version: powermockVersion
 }
 
 // In this section you declare where to find the dependencies of your project
@@ -43,8 +53,6 @@ compileJava   {
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
 }
-
-version = "1.0.0"
 
 jar {
     manifest {

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,172 @@
+#!/usr/bin/env sh
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "$*"
+}
+
+die () {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Escape application args
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
+}
+APP_ARGS=$(save "$@")
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
+
+exec "$JAVACMD" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnector.java
+++ b/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnector.java
@@ -44,9 +44,6 @@ public class KafkaSourceConnector extends SourceConnector {
     public void start(Map<String, String> config) throws ConfigException {
         LOG.info("Connector: start()");
         connectorConfig = new KafkaSourceConnectorConfig(config);
-        if (connectorConfig.getList(KafkaSourceConnectorConfig.SOURCE_BOOTSTRAP_SERVERS_CONFIG).isEmpty()) {
-            throw new ConfigException("At least one bootstrap server must be configured in " + KafkaSourceConnectorConfig.SOURCE_BOOTSTRAP_SERVERS_CONFIG);
-        }
         LOG.info("Starting Partition Monitor to monitor source kafka cluster partitions");
         partitionMonitor = new PartitionMonitor(context, connectorConfig);
         partitionMonitor.start();

--- a/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnector.java
+++ b/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnector.java
@@ -65,7 +65,7 @@ public class KafkaSourceConnector extends SourceConnector {
             .collect(Collectors.toList());
         int taskCount = Math.min(maxTasks, leaderTopicPartitions.size());
         if (taskCount < 1) {
-            LOG.info("No tasks to start.");
+            LOG.warn("No tasks to start.");
             return new ArrayList<>();
         }
         return ConnectorUtils.groupPartitions(leaderTopicPartitions, taskCount)
@@ -83,7 +83,7 @@ public class KafkaSourceConnector extends SourceConnector {
     public void stop() {
         LOG.info("Connector received stop(). Cleaning Up.");
         partitionMonitor.shutdown();
-        LOG.info("Stopped.");
+        LOG.info("Connector stopped.");
     }
 
     @Override

--- a/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorConfig.java
+++ b/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorConfig.java
@@ -45,9 +45,9 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
     public static final String DESTINATION_PREFIX =         "destination.";
 
     // Any config beginning with this prefix will set the config parameters for the kafka consumer used in this connector
-    public static final String CONSUMER_PREFIX =            "consumer.";
+    public static final String CONSUMER_PREFIX =            "connector.consumer.";
     // Any config beginning with this prefix will set the config parameters for the admin client used by the partition monitor
-    public static final String ADMIN_CLIENT_PREFIX =        "admin.";
+    public static final String ADMIN_CLIENT_PREFIX =        "connector.admin.";
 
     public static final String TASK_PREFIX =                "task.";
 
@@ -60,6 +60,7 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
     public static final String SOURCE_TOPIC_WHITELIST_DOC =            "Regular expressions indicating the topics to consume from the source cluster. " +
             "Under the hood, the regex is compiled to a <code>java.util.regex.Pattern</code>. " +
             "For convenience, comma (',') is interpreted as interpreted as the regex-choice symbol ('|').";
+    public static final Object SOURCE_TOPIC_WHITELIST_DEFAULT =         ConfigDef.NO_DEFAULT_VALUE;
     public static final String DESTINATION_TOPIC_PREFIX_CONFIG =        DESTINATION_PREFIX.concat("topics.prefix");
     public static final String DESTINATION_TOPIC_PREFIX_DOC =           "Prefix to add to source topic names when delivering messages to destination server";
     public static final String DESTINATION_TOPIC_PREFIX_DEFAULT =       "";
@@ -90,6 +91,8 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
     // General Source Kafka Config - Applies to Consumer and Admin Client if not overridden by CONSUMER_PREFIX or ADMIN_CLIENT_PREFIX
     public static final String SOURCE_BOOTSTRAP_SERVERS_CONFIG =          SOURCE_PREFIX.concat("bootstrap.servers");
     public static final String SOURCE_BOOTSTRAP_SERVERS_DOC =             "list of kafka brokers to use to bootstrap the source cluster";
+    public static final Object SOURCE_BOOTSTRAP_SERVERS_DEFAULT =         ConfigDef.NO_DEFAULT_VALUE;
+
     // These are the kafka consumer configs we override defaults for
     // Note that *any* kafka consumer config can be set by adding the
     // CONSUMER_PREFIX in front of the standard consumer config strings
@@ -111,17 +114,15 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
             "Note that these offsets are not used to resume the connector (They are stored in the Kafka Connect offset store), but may be useful in monitoring the current offset lag " +
             "of this connector on the source cluster";
     public static final Boolean CONSUMER_ENABLE_AUTO_COMMIT_DEFAULT =        true;
-    // TODO: If enable.auto.commit is set to true, AND group.id is null, then throw a config error. Need to set group.id if enable.auto.commit is turned on so offsets have a group assigned with them
-    /*
+
     public static final String CONSUMER_GROUP_ID_CONFIG =         SOURCE_PREFIX.concat("group.id");
     public static final String CONSUMER_GROUP_ID_DOC =            "Source Kafka Consumer group id. This must be set if source.enable.auto.commit is set as a group id is required for offset tracking on the source cluster";
-    public static final String CONSUMER_GROUP_ID_DEFAULT =        null;
-    */
+    public static final Object CONSUMER_GROUP_ID_DEFAULT =        ConfigDef.NO_DEFAULT_VALUE;
 
 
     // Config definition
     public static ConfigDef CONFIG = new ConfigDef()
-        .define(SOURCE_TOPIC_WHITELIST_CONFIG, Type.STRING, ConfigDef.NO_DEFAULT_VALUE, TopicWhitelistRegexValidator, Importance.HIGH, SOURCE_TOPIC_WHITELIST_DOC)
+        .define(SOURCE_TOPIC_WHITELIST_CONFIG, Type.STRING, SOURCE_TOPIC_WHITELIST_DEFAULT, TopicWhitelistRegexValidator, Importance.HIGH, SOURCE_TOPIC_WHITELIST_DOC)
         .define(DESTINATION_TOPIC_PREFIX_CONFIG, Type.STRING, DESTINATION_TOPIC_PREFIX_DEFAULT, Importance.MEDIUM, DESTINATION_TOPIC_PREFIX_DOC)
         .define(INCLUDE_MESSAGE_HEADERS_CONFIG, Type.BOOLEAN, INCLUDE_MESSAGE_HEADERS_DEFAULT, Importance.MEDIUM, INCLUDE_MESSAGE_HEADERS_DOC)
         .define(TOPIC_LIST_TIMEOUT_MS_CONFIG, Type.INT, TOPIC_LIST_TIMEOUT_MS_DEFAULT, Importance.LOW, TOPIC_LIST_TIMEOUT_MS_DOC)
@@ -129,12 +130,13 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
         .define(RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG, Type.BOOLEAN, RECONFIGURE_TASKS_ON_LEADER_CHANGE_DEFAULT, Importance.MEDIUM, RECONFIGURE_TASKS_ON_LEADER_CHANGE_DOC)
         .define(POLL_LOOP_TIMEOUT_MS_CONFIG, Type.INT, POLL_LOOP_TIMEOUT_MS_DEFAULT, Importance.LOW, POLL_LOOP_TIMEOUT_MS_DOC)
         .define(MAX_SHUTDOWN_WAIT_MS_CONFIG, Type.INT, MAX_SHUTDOWN_WAIT_MS_DEFAULT, Importance.LOW, MAX_SHUTDOWN_WAIT_MS_DOC)
-        .define(SOURCE_BOOTSTRAP_SERVERS_CONFIG, Type.LIST, ConfigDef.NO_DEFAULT_VALUE, NonEmptyListValidator, Importance.HIGH, SOURCE_BOOTSTRAP_SERVERS_DOC)
+        .define(SOURCE_BOOTSTRAP_SERVERS_CONFIG, Type.LIST, SOURCE_BOOTSTRAP_SERVERS_DEFAULT, NonEmptyListValidator, Importance.HIGH, SOURCE_BOOTSTRAP_SERVERS_DOC)
         .define(CONSUMER_MAX_POLL_RECORDS_CONFIG, Type.INT, CONSUMER_MAX_POLL_RECORDS_DEFAULT, Importance.LOW, CONSUMER_MAX_POLL_RECORDS_DOC)
         .define(CONSUMER_AUTO_OFFSET_RESET_CONFIG, Type.STRING, CONSUMER_AUTO_OFFSET_RESET_DEFAULT, CONSUMER_AUTO_OFFSET_RESET_VALIDATOR, Importance.MEDIUM, CONSUMER_AUTO_OFFSET_RESET_DOC)
         .define(CONSUMER_KEY_DESERIALIZER_CONFIG, Type.STRING, CONSUMER_KEY_DESERIALIZER_DEFAULT, Importance.LOW, CONSUMER_KEY_DESERIALIZER_DOC)
         .define(CONSUMER_VALUE_DESERIALIZER_CONFIG, Type.STRING, CONSUMER_VALUE_DESERIALIZER_DEFAULT, Importance.LOW, CONSUMER_VALUE_DESERIALIZER_DOC)
-        .define(CONSUMER_ENABLE_AUTO_COMMIT_CONFIG, Type.BOOLEAN, CONSUMER_ENABLE_AUTO_COMMIT_DEFAULT, Importance.LOW, CONSUMER_ENABLE_AUTO_COMMIT_DOC);
+        .define(CONSUMER_ENABLE_AUTO_COMMIT_CONFIG, Type.BOOLEAN, CONSUMER_ENABLE_AUTO_COMMIT_DEFAULT, Importance.LOW, CONSUMER_ENABLE_AUTO_COMMIT_DOC)
+        .define(CONSUMER_GROUP_ID_CONFIG, Type.STRING, CONSUMER_GROUP_ID_DEFAULT, new ConfigDef.NonEmptyString(), Importance.MEDIUM, CONSUMER_GROUP_ID_DOC);
 
     public KafkaSourceConnectorConfig(Map<String, String> props) {
         super(CONFIG, props);

--- a/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorConfig.java
+++ b/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorConfig.java
@@ -20,44 +20,51 @@ import java.util.*;
 public class KafkaSourceConnectorConfig extends AbstractConfig {
 
     // Config Prefixes
+    public static final String SOURCE_PREFIX =              "source.";
+    public static final String DESTINATION_PREFIX =         "destination.";
     public static final String CONSUMER_PREFIX =            "consumer.";
-    public static final String PARTITION_MONITOR_PREFIX =   "partition.monitor.";
+    public static final String ADMIN_CLIENT_PREFIX =        "admin.";
+
     public static final String TASK_PREFIX =                "task.";
 
     // Topic partition list we send to each task. Not user configurable.
     public static final String TASK_LEADER_TOPIC_PARTITION_CONFIG = TASK_PREFIX.concat("leader.topic.partitions");
 
-
     // General Connector config
-    // Topics - Note that ONE of source.topics or source.topics.regex can be set, not both.
-    public static final String SOURCE_TOPICS_CONFIG =                   "source.topics";
-    public static final String SRC_TOPICS_DOC =                         "List of topics to consume";
-    public static final String SOURCE_TOPICS_DEFAULT =                  "";
-    public static final String SOURCE_TOPICS_REGEX_CONFIG =             "source.topics.regex";
-    public static final String SOURCE_TOPICS_REGEX_DOC =                "Regular expression giving topics to consume. " +
-            "Under the hood, the regex is compiled to a <code>java.util.regex.Pattern</code>." +
-            "Only one of " + SOURCE_TOPICS_CONFIG + " or " + SOURCE_TOPICS_REGEX_CONFIG + " should be specified.";
-    public static final String SOURCE_TOPICS_REGEX_DEFAULT =            "";
-    public static final String DESTINATION_TOPIC_PREFIX_CONFIG =        "destination.topics.prefix";
-    public static final String DESTINATION_TOPIC_PREFIX_DOC =           "Prefix to add to topic names to generate the name of the Kafka topic to publish data to";
+    // Topics
+    public static final String SOURCE_TOPIC_WHITELIST_CONFIG =         SOURCE_PREFIX.concat("topic.whitelist");
+    public static final String SOURCE_TOPIC_WHITELIST_DOC =            "List of regular expressions indicating the topics to consume from the source cluster. " +
+            "Under the hood, the regex is compiled to a <code>java.util.regex.Pattern</code>.";
+    public static final String DESTINATION_TOPIC_PREFIX_CONFIG =        DESTINATION_PREFIX.concat("topics.prefix");
+    public static final String DESTINATION_TOPIC_PREFIX_DOC =           "Prefix to add to source topic names when delivering messages to destination server";
     public static final String DESTINATION_TOPIC_PREFIX_DEFAULT =       "";
+
     // Message headers
     public static final String INCLUDE_MESSAGE_HEADERS_CONFIG =         "include.message.headers";
-    public static final String INCLUDE_MESSAGE_HEADERS_DOC =            "Indicates that message headers from source records should be included in output";
+    public static final String INCLUDE_MESSAGE_HEADERS_DOC =            "Indicates whether message headers from source records should be included in output";
     public static final boolean INCLUDE_MESSAGE_HEADERS_DEFAULT =       true;
-    // Other connector configs
-    public static final String POLL_TIMEOUT_MS_CONFIG =         "poll.timeout.ms";
-    public static final String POLL_TIMEOUT_MS_DOC =            "Maximum amount of time to wait in each poll loop without data before cancelling the poll and returning control to the worker task";
-    public static final int POLL_TIMEOUT_MS_DEFAULT =           1000;
+
+    // Partition Monitor
+    public static final String TOPIC_LIST_TIMEOUT_MS_CONFIG =               "topic.list.timeout.ms";
+    public static final String TOPIC_LIST_TIMEOUT_MS_DOC  =                 "Amount of time the partition monitor thread should wait for kafka to return topic information before logging a timeout error.";
+    public static final int TOPIC_LIST_TIMEOUT_MS_DEFAULT =                 60000;
+    public static final String TOPIC_LIST_POLL_INTERVAL_MS_CONFIG =         "topic.list.poll.interval.ms";
+    public static final String TOPIC_LIST_POLL_INTERVAL_MS_DOC =            "How long to wait before re-querying the source cluster for a change in the partitions to be consumed";
+    public static final int TOPIC_LIST_POLL_INTERVAL_MS_DEFAULT =           300000;
+    public static final String RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG =  "reconfigure.tasks.on.partition.leader.change";
+    public static final String RECONFIGURE_TASKS_ON_LEADER_CHANGE_DOC =     "Indicates whether the partition monitor should request a task reconfiguration when partition leaders have changed";
+    public static final boolean RECONFIGURE_TASKS_ON_LEADER_CHANGE_DEFAULT = false;
+    // Internal Timing Stuff
+    public static final String POLL_LOOP_TIMEOUT_MS_CONFIG =    "poll.loop.timeout.ms";
+    public static final String POLL_LOOP_TIMEOUT_MS_DOC =       "Maximum amount of time to wait in each poll loop without data before cancelling the poll and returning control to the worker task";
+    public static final int POLL_LOOP_TIMEOUT_MS_DEFAULT =      1000;
     public static final String MAX_SHUTDOWN_WAIT_MS_CONFIG =    "max.shutdown.wait.ms";
     public static final String MAX_SHUTDOWN_WAIT_MS_DOC =       "Maximum amount of time to wait before forcing the consumer to close";
-    public static final int MAX_SHUTDOWN_WAIT_MS_DEFAULT =      1500;
+    public static final int MAX_SHUTDOWN_WAIT_MS_DEFAULT =      2000;
 
-
-
-    // General Source Kafka Config
-    public static final String CONSUMER_BOOTSTRAP_SERVERS_CONFIG =          CONSUMER_PREFIX.concat("bootstrap.servers");
-    public static final String CONSUMER_BOOTSTRAP_SERVERS_DOC =             "list of kafka brokers to use to bootstrap the source cluster";
+    // General Source Kafka Config - Applies to Consumer and Admin Client if not overridden by CONSUMER_PREFIX or ADMIN_CLIENT_PREFIX
+    public static final String SOURCE_BOOTSTRAP_SERVERS_CONFIG =          SOURCE_PREFIX.concat("bootstrap.servers");
+    public static final String SOURCE_BOOTSTRAP_SERVERS_DOC =             "list of kafka brokers to use to bootstrap the source cluster";
     // These are the kafka consumer configs we override defaults for
     // Note that *any* kafka consumer config can be set by adding the
     // CONSUMER_PREFIX in front of the standard consumer config strings
@@ -73,32 +80,22 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
     public static final String CONSUMER_VALUE_DESERIALIZER_CONFIG =         CONSUMER_PREFIX.concat("value.deserializer");
     public static final String CONSUMER_VALUE_DESERIALIZER_DOC =            "Value deserializer to use for the kafka consumers connecting to the source cluster.";
     public static final String CONSUMER_VALUE_DESERIALIZER_DEFAULT =        "org.apache.kafka.common.serialization.ByteArrayDeserializer";
-    // Partition Monitor
-    public static final String PARTITION_MONITOR_TOPIC_LIST_TIMEOUT_MS_CONFIG =                 PARTITION_MONITOR_PREFIX.concat("topic.list.timeout.ms");
-    public static final String PARTITION_MONITOR_TOPIC_LIST_TIMEOUT_MS_DOC  =                   "Amount of time the partition monitor thread should wait for kafka to return topic information before logging a timeout error.";
-    public static final int PARTITION_MONITOR_TOPIC_LIST_TIMEOUT_MS_DEFAULT =                   60000;
-    public static final String PARTITION_MONITOR_POLL_INTERVAL_MS_CONFIG =                      PARTITION_MONITOR_PREFIX.concat("poll.interval.ms");
-    public static final String PARTITION_MONITOR_POLL_INTERVAL_MS_DOC =                         "How long to wait before re-querying the source cluster for a change in the partitions to be consumed";
-    public static final int PARTITION_MONITOR_POLL_INTERVAL_MS_DEFAULT =                        300000;
-    public static final String PARTITION_MONITOR_RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG =    PARTITION_MONITOR_PREFIX.concat("reconfigure.tasks.on.leader.change");
-    public static final String PARTITION_RECONFIGURE_TASKS_ON_LEADER_CHANGE_DOC =               "Indicates whether the partition monitor should request a task reconfiguration when partition leaders have changed";
-    public static final boolean PARTITION_RECONFIGURE_TASKS_ON_LEADER_CHANGE_DEFAULT =          false;
+    
 
 
 
 
     // Config definition
     public static ConfigDef CONFIG = new ConfigDef()
-        .define(SOURCE_TOPICS_CONFIG, Type.LIST, SOURCE_TOPICS_DEFAULT, ConfigDef.Importance.HIGH, SRC_TOPICS_DOC)
-        .define(SOURCE_TOPICS_REGEX_CONFIG, Type.STRING, SOURCE_TOPICS_REGEX_DEFAULT, ConfigDef.Importance.HIGH, SOURCE_TOPICS_REGEX_DOC)
+        .define(SOURCE_TOPIC_WHITELIST_CONFIG, Type.LIST, Importance.HIGH, SOURCE_TOPIC_WHITELIST_DOC)
         .define(DESTINATION_TOPIC_PREFIX_CONFIG, Type.STRING, DESTINATION_TOPIC_PREFIX_DEFAULT, Importance.MEDIUM, DESTINATION_TOPIC_PREFIX_DOC)
         .define(INCLUDE_MESSAGE_HEADERS_CONFIG, Type.BOOLEAN, INCLUDE_MESSAGE_HEADERS_DEFAULT, Importance.MEDIUM, INCLUDE_MESSAGE_HEADERS_DOC)
-        .define(PARTITION_MONITOR_TOPIC_LIST_TIMEOUT_MS_CONFIG, Type.INT, PARTITION_MONITOR_TOPIC_LIST_TIMEOUT_MS_DEFAULT, Importance.LOW, PARTITION_MONITOR_TOPIC_LIST_TIMEOUT_MS_DOC)
-        .define(PARTITION_MONITOR_POLL_INTERVAL_MS_CONFIG, Type.INT, PARTITION_MONITOR_POLL_INTERVAL_MS_DEFAULT, Importance.MEDIUM, PARTITION_MONITOR_POLL_INTERVAL_MS_DOC)
-        .define(PARTITION_MONITOR_RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG, Type.BOOLEAN, PARTITION_RECONFIGURE_TASKS_ON_LEADER_CHANGE_DEFAULT, Importance.MEDIUM, PARTITION_RECONFIGURE_TASKS_ON_LEADER_CHANGE_DOC)
-        .define(POLL_TIMEOUT_MS_CONFIG, Type.INT, POLL_TIMEOUT_MS_DEFAULT, Importance.LOW, POLL_TIMEOUT_MS_DOC)
+        .define(TOPIC_LIST_TIMEOUT_MS_CONFIG, Type.INT, TOPIC_LIST_TIMEOUT_MS_DEFAULT, Importance.LOW, TOPIC_LIST_TIMEOUT_MS_DOC)
+        .define(TOPIC_LIST_POLL_INTERVAL_MS_CONFIG, Type.INT, TOPIC_LIST_POLL_INTERVAL_MS_DEFAULT, Importance.MEDIUM, TOPIC_LIST_POLL_INTERVAL_MS_DOC)
+        .define(RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG, Type.BOOLEAN, RECONFIGURE_TASKS_ON_LEADER_CHANGE_DEFAULT, Importance.MEDIUM, RECONFIGURE_TASKS_ON_LEADER_CHANGE_DOC)
+        .define(POLL_LOOP_TIMEOUT_MS_CONFIG, Type.INT, POLL_LOOP_TIMEOUT_MS_DEFAULT, Importance.LOW, POLL_LOOP_TIMEOUT_MS_DOC)
         .define(MAX_SHUTDOWN_WAIT_MS_CONFIG, Type.INT, MAX_SHUTDOWN_WAIT_MS_DEFAULT, Importance.LOW, MAX_SHUTDOWN_WAIT_MS_DOC)
-        .define(CONSUMER_BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Importance.HIGH, CONSUMER_BOOTSTRAP_SERVERS_DOC)
+        .define(SOURCE_BOOTSTRAP_SERVERS_CONFIG, Type.LIST, Importance.HIGH, SOURCE_BOOTSTRAP_SERVERS_DOC)
         .define(CONSUMER_MAX_POLL_RECORDS_CONFIG, Type.INT, CONSUMER_MAX_POLL_RECORDS_DEFAULT, Importance.LOW, CONSUMER_MAX_POLL_RECORDS_DOC)
         .define(CONSUMER_AUTO_OFFSET_RESET_CONFIG, Type.STRING, CONSUMER_AUTO_OFFSET_RESET_DEFAULT, Importance.MEDIUM, CONSUMER_AUTO_OFFSET_RESET_DOC)
         .define(CONSUMER_KEY_DESERIALIZER_CONFIG, Type.STRING, CONSUMER_KEY_DESERIALIZER_DEFAULT, Importance.LOW, CONSUMER_KEY_DESERIALIZER_DOC)
@@ -133,17 +130,39 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
     public Map<String, String> allAsStrings() {
         Map<String, String> result = new HashMap<>();
         result.put(DESTINATION_TOPIC_PREFIX_CONFIG, getString(DESTINATION_TOPIC_PREFIX_CONFIG));
-        result.put(POLL_TIMEOUT_MS_CONFIG, String.valueOf(getInt(POLL_TIMEOUT_MS_CONFIG)));
+        result.put(INCLUDE_MESSAGE_HEADERS_CONFIG, String.valueOf(getBoolean(INCLUDE_MESSAGE_HEADERS_CONFIG)));
+        result.put(TOPIC_LIST_TIMEOUT_MS_CONFIG, String.valueOf(getInt(TOPIC_LIST_TIMEOUT_MS_CONFIG)));
+        result.put(TOPIC_LIST_POLL_INTERVAL_MS_CONFIG, String.valueOf(getInt(TOPIC_LIST_POLL_INTERVAL_MS_CONFIG)));
+        result.put(RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG, String.valueOf(getBoolean(RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG)));
+        result.put(POLL_LOOP_TIMEOUT_MS_CONFIG, String.valueOf(getInt(POLL_LOOP_TIMEOUT_MS_CONFIG)));
         result.put(MAX_SHUTDOWN_WAIT_MS_CONFIG, String.valueOf(getInt(MAX_SHUTDOWN_WAIT_MS_CONFIG)));
         result.put(CONSUMER_MAX_POLL_RECORDS_CONFIG, String.valueOf(getInt(CONSUMER_MAX_POLL_RECORDS_CONFIG)));
         result.put(CONSUMER_AUTO_OFFSET_RESET_CONFIG, getString(CONSUMER_AUTO_OFFSET_RESET_CONFIG));
         result.put(CONSUMER_KEY_DESERIALIZER_CONFIG, getString(CONSUMER_KEY_DESERIALIZER_CONFIG));
         result.put(CONSUMER_VALUE_DESERIALIZER_CONFIG, getString(CONSUMER_VALUE_DESERIALIZER_CONFIG));
-        result.put(PARTITION_MONITOR_TOPIC_LIST_TIMEOUT_MS_CONFIG, String.valueOf(getInt(PARTITION_MONITOR_TOPIC_LIST_TIMEOUT_MS_CONFIG)));
-        result.put(PARTITION_MONITOR_POLL_INTERVAL_MS_CONFIG, String.valueOf(getInt(PARTITION_MONITOR_POLL_INTERVAL_MS_CONFIG)));
-        result.put(PARTITION_MONITOR_RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG, String.valueOf(getBoolean(PARTITION_MONITOR_RECONFIGURE_TASKS_ON_LEADER_CHANGE_CONFIG)));
-        result.putAll(originalsStrings()); // Will set any values without defaults and will capture additional configs like consumer settings
+        result.putAll(originalsStrings()); // Will set any values without defaults and will capture additional configs like consumer settings if supplied
         return result;
     }
+
+    // Return a Properties Object that can be passed to AdminClient.create to configure a Kafka AdminClient instance
+    public Properties getAdminClientProperties() {
+        Properties adminClientProps = new Properties();
+        // By Default use any settings under SOURCE_PREFIX
+        adminClientProps.putAll(allWithPrefix(KafkaSourceConnectorConfig.SOURCE_PREFIX));
+        // But override with anything under ADMIN_CLIENT_PREFIX
+        adminClientProps.putAll(allWithPrefix(KafkaSourceConnectorConfig.ADMIN_CLIENT_PREFIX));
+        return adminClientProps;
+    }
+
+    // Return a Properties Object that can be passed to KafkaConsumer
+    public Properties getKafkaConsumerProperties() {
+        Properties kafkaConsumerProps = new Properties();
+        // By Default use any settings under SOURCE_PREFIX
+        kafkaConsumerProps.putAll(allWithPrefix(KafkaSourceConnectorConfig.SOURCE_PREFIX));
+        // But override with anything under CONSUMER_PREFIX
+        kafkaConsumerProps.putAll(allWithPrefix(KafkaSourceConnectorConfig.CONSUMER_PREFIX));
+        return kafkaConsumerProps;
+    }
+
 
 }

--- a/src/main/java/com/comcast/kafka/connect/kafka/PartitionMonitor.java
+++ b/src/main/java/com/comcast/kafka/connect/kafka/PartitionMonitor.java
@@ -14,7 +14,6 @@ import org.apache.kafka.clients.admin.*;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.connector.ConnectorContext;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.common.config.ConfigException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/comcast/kafka/connect/kafka/PartitionMonitor.java
+++ b/src/main/java/com/comcast/kafka/connect/kafka/PartitionMonitor.java
@@ -93,7 +93,7 @@ public class PartitionMonitor {
                         else
                             LOG.info("No partition changes which require reconfiguration have been detected.");
                     } catch (TimeoutException e) {
-                        LOG.error("Timeout while waiting for AdminClient to return topic list. This likely indicates a (possibly transient) connection issue, but could be an indicator that the timeout is set too low. {}", e);
+                        LOG.error("Timeout while waiting for AdminClient to return topic list. This indicates a (possibly transient) connection issue, or is an indicator that the timeout is set too low. {}", e);
                     } catch (ExecutionException e) {
                         LOG.error("Unexpected ExecutionException. {}", e);
                     } catch (InterruptedException e) {
@@ -138,14 +138,14 @@ public class PartitionMonitor {
     }
 
     // Allow the main thread a chance to shut down gracefully
-    public synchronized void shutdown() {
+    public void shutdown() {
         LOG.info("Shutdown called.");
         long startWait = System.currentTimeMillis();
         shutdown.set(true);
         partitionMonitorClient.close( maxShutdownWaitMs - (System.currentTimeMillis() - startWait), TimeUnit.MILLISECONDS);
         // Cancel our scheduled task, but wait for an existing task to complete if running
         pollHandle.cancel(false);
-        // Ask nicely to shut down the executor service if it hasnt already
+        // Ask nicely to shut down the partition monitor executor service if it hasn't already
         if (!pollExecutorService.isShutdown()) {
             try {
                 pollExecutorService.awaitTermination(maxShutdownWaitMs - (System.currentTimeMillis() - startWait), TimeUnit.MILLISECONDS);

--- a/src/test/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorTest.java
+++ b/src/test/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorTest.java
@@ -50,6 +50,7 @@ public class KafkaSourceConnectorTest extends EasyMockSupport {
     private static final String SOURCE_BOOTSTRAP_SERVERS_CONFIG = "localhost:6000";
     private static final String POLL_LOOP_TIMEOUT_MS_VALUE = "2000";
     private static final String TOPIC_LIST_TIMEOUT_MS_VALUE = "5000";
+    private static final String CONSUMER_GROUP_ID_VALUE = "test-consumer-group";
 
     @Before
     public void setUp() throws Exception {
@@ -64,6 +65,7 @@ public class KafkaSourceConnectorTest extends EasyMockSupport {
         sourceProperties.put(KafkaSourceConnectorConfig.SOURCE_BOOTSTRAP_SERVERS_CONFIG, SOURCE_BOOTSTRAP_SERVERS_CONFIG);
         sourceProperties.put(KafkaSourceConnectorConfig.POLL_LOOP_TIMEOUT_MS_CONFIG, POLL_LOOP_TIMEOUT_MS_VALUE);
         sourceProperties.put(KafkaSourceConnectorConfig.TOPIC_LIST_TIMEOUT_MS_CONFIG, TOPIC_LIST_TIMEOUT_MS_VALUE);
+        sourceProperties.put(KafkaSourceConnectorConfig.CONSUMER_GROUP_ID_CONFIG, CONSUMER_GROUP_ID_VALUE);
 
         // Default leader topic partitions to return (just one)
         stubLeaderTopicPartitions = new HashSet<>();

--- a/src/test/java/com/comcast/kafka/connect/kafka/KafkaSourceTaskTest.java
+++ b/src/test/java/com/comcast/kafka/connect/kafka/KafkaSourceTaskTest.java
@@ -32,6 +32,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.time.Duration;
 import java.util.*;
 
 import static junit.framework.TestCase.assertTrue;
@@ -57,7 +58,7 @@ public class KafkaSourceTaskTest {
     private KafkaSourceConnectorConfig config;
 
     private String MAX_SHUTDOWN_WAIT_MS_VALUE = "2000";
-    private String POLL_LOOP_TIMEOUT_MS_VALUE = "25";
+    private int POLL_LOOP_TIMEOUT_MS_VALUE = 25;
     private String DESTINATION_TOPIC_PREFIX_VALUE = "test.destination";
     private String INCLUDE_MESSAGE_HEADERS_VALUE = "false";
     private String CONSUMER_AUTO_OFFSET_RESET_VALUE = "0";
@@ -86,7 +87,7 @@ public class KafkaSourceTaskTest {
         opts = new HashMap<>();
         opts.put(KafkaSourceConnectorConfig.SOURCE_TOPIC_WHITELIST_CONFIG, SOURCE_TOPICS_WHITELIST_VALUE);
         opts.put(KafkaSourceConnectorConfig.MAX_SHUTDOWN_WAIT_MS_CONFIG, MAX_SHUTDOWN_WAIT_MS_VALUE);
-        opts.put(KafkaSourceConnectorConfig.POLL_LOOP_TIMEOUT_MS_CONFIG, POLL_LOOP_TIMEOUT_MS_VALUE);
+        opts.put(KafkaSourceConnectorConfig.POLL_LOOP_TIMEOUT_MS_CONFIG, String.valueOf(POLL_LOOP_TIMEOUT_MS_VALUE));
         opts.put(KafkaSourceConnectorConfig.DESTINATION_TOPIC_PREFIX_CONFIG, DESTINATION_TOPIC_PREFIX_VALUE);
         opts.put(KafkaSourceConnectorConfig.INCLUDE_MESSAGE_HEADERS_CONFIG, INCLUDE_MESSAGE_HEADERS_VALUE);
         opts.put(KafkaSourceConnectorConfig.CONSUMER_AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_VALUE);
@@ -292,7 +293,7 @@ public class KafkaSourceTaskTest {
     @Test
     public void testPollNoRecords() throws Exception {
         mockConsumerInitialization();
-        EasyMock.expect(consumer.poll(25)).andReturn(new ConsumerRecords<>(Collections.EMPTY_MAP));
+        EasyMock.expect(consumer.poll(Duration.ofMillis(POLL_LOOP_TIMEOUT_MS_VALUE))).andReturn(new ConsumerRecords<>(Collections.EMPTY_MAP));
         replayAll();
 
         objectUnderTest.start(opts);
@@ -307,7 +308,7 @@ public class KafkaSourceTaskTest {
     @Test
     public void testPollRecordReturnedNoIncludeHeaders() throws Exception {
         mockConsumerInitialization();
-        EasyMock.expect(consumer.poll(25)).andReturn(createTestRecords());
+        EasyMock.expect(consumer.poll(Duration.ofMillis(POLL_LOOP_TIMEOUT_MS_VALUE))).andReturn(createTestRecords());
         replayAll();
 
         objectUnderTest.start(opts);
@@ -350,7 +351,7 @@ public class KafkaSourceTaskTest {
 
 
         // expectation for poll
-        EasyMock.expect(consumer.poll(25)).andReturn(createTestRecordsWithHeaders());
+        EasyMock.expect(consumer.poll(Duration.ofMillis(POLL_LOOP_TIMEOUT_MS_VALUE))).andReturn(createTestRecordsWithHeaders());
         replayAll();
 
         objectUnderTest.start(opts);
@@ -371,7 +372,7 @@ public class KafkaSourceTaskTest {
 
         consumer.wakeup();
         EasyMock.expectLastCall();
-        consumer.close(EasyMock.anyLong(), EasyMock.anyObject());
+        consumer.close(EasyMock.anyObject());
         EasyMock.expectLastCall();
 
         replayAll();

--- a/src/test/java/com/comcast/kafka/connect/kafka/KafkaSourceTaskTest.java
+++ b/src/test/java/com/comcast/kafka/connect/kafka/KafkaSourceTaskTest.java
@@ -56,15 +56,16 @@ public class KafkaSourceTaskTest {
     private Properties props;
     private KafkaSourceConnectorConfig config;
 
-    private String MAX_SHUTDOWN_WAIT_MS_CONFIG = "2000";
-    private String POLL_LOOP_TIMEOUT_MS_CONFIG = "5";
-    private String DESTINATION_TOPIC_PREFIX_CONFIG = "test.destination";
-    private String INCLUDE_MESSAGE_HEADERS_CONFIG = "false";
-    private String CONSUMER_AUTO_OFFSET_RESET_CONFIG = "0";
-    private String SOURCE_BOOTSTRAP_SERVERS_CONFIG = "localhost:6000";
-    private String TASK_LEADER_TOPIC_PARTITION_CONFIG = "0:test.topic:1";
-    private String AUTO_OFFSET_RESET_CONFIG = "latest";
-    private String SOURCE_TOPICS_WHITELIST_CONFIG = "test*";
+    private String MAX_SHUTDOWN_WAIT_MS_VALUE = "2000";
+    private String POLL_LOOP_TIMEOUT_MS_VALUE = "25";
+    private String DESTINATION_TOPIC_PREFIX_VALUE = "test.destination";
+    private String INCLUDE_MESSAGE_HEADERS_VALUE = "false";
+    private String CONSUMER_AUTO_OFFSET_RESET_VALUE = "0";
+    private String SOURCE_BOOTSTRAP_SERVERS_VALUE = "localhost:6000";
+    private String TASK_LEADER_TOPIC_PARTITION_VALUE = "0:test.topic:1";
+    private String AUTO_OFFSET_RESET_VALUE = "latest";
+    private String SOURCE_TOPICS_WHITELIST_VALUE = "test*";
+    private static final String CONSUMER_GROUP_ID_VALUE = "test-consumer-group";
 
 
     private String FIRST_TOPIC = "test.topic";
@@ -83,15 +84,16 @@ public class KafkaSourceTaskTest {
     public void setup() {
 
         opts = new HashMap<>();
-        opts.put(KafkaSourceConnectorConfig.SOURCE_TOPIC_WHITELIST_CONFIG, SOURCE_TOPICS_WHITELIST_CONFIG);
-        opts.put(KafkaSourceConnectorConfig.MAX_SHUTDOWN_WAIT_MS_CONFIG, MAX_SHUTDOWN_WAIT_MS_CONFIG);
-        opts.put(KafkaSourceConnectorConfig.POLL_LOOP_TIMEOUT_MS_CONFIG, POLL_LOOP_TIMEOUT_MS_CONFIG);
-        opts.put(KafkaSourceConnectorConfig.DESTINATION_TOPIC_PREFIX_CONFIG, DESTINATION_TOPIC_PREFIX_CONFIG);
-        opts.put(KafkaSourceConnectorConfig.INCLUDE_MESSAGE_HEADERS_CONFIG, INCLUDE_MESSAGE_HEADERS_CONFIG);
-        opts.put(KafkaSourceConnectorConfig.CONSUMER_AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG);
-        opts.put(KafkaSourceConnectorConfig.SOURCE_BOOTSTRAP_SERVERS_CONFIG, SOURCE_BOOTSTRAP_SERVERS_CONFIG);
-        opts.put(KafkaSourceConnectorConfig.TASK_LEADER_TOPIC_PARTITION_CONFIG, TASK_LEADER_TOPIC_PARTITION_CONFIG);
-        opts.put(KafkaSourceConnectorConfig.CONSUMER_AUTO_OFFSET_RESET_CONFIG, AUTO_OFFSET_RESET_CONFIG);
+        opts.put(KafkaSourceConnectorConfig.SOURCE_TOPIC_WHITELIST_CONFIG, SOURCE_TOPICS_WHITELIST_VALUE);
+        opts.put(KafkaSourceConnectorConfig.MAX_SHUTDOWN_WAIT_MS_CONFIG, MAX_SHUTDOWN_WAIT_MS_VALUE);
+        opts.put(KafkaSourceConnectorConfig.POLL_LOOP_TIMEOUT_MS_CONFIG, POLL_LOOP_TIMEOUT_MS_VALUE);
+        opts.put(KafkaSourceConnectorConfig.DESTINATION_TOPIC_PREFIX_CONFIG, DESTINATION_TOPIC_PREFIX_VALUE);
+        opts.put(KafkaSourceConnectorConfig.INCLUDE_MESSAGE_HEADERS_CONFIG, INCLUDE_MESSAGE_HEADERS_VALUE);
+        opts.put(KafkaSourceConnectorConfig.CONSUMER_AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_VALUE);
+        opts.put(KafkaSourceConnectorConfig.SOURCE_BOOTSTRAP_SERVERS_CONFIG, SOURCE_BOOTSTRAP_SERVERS_VALUE);
+        opts.put(KafkaSourceConnectorConfig.TASK_LEADER_TOPIC_PARTITION_CONFIG, TASK_LEADER_TOPIC_PARTITION_VALUE);
+        opts.put(KafkaSourceConnectorConfig.CONSUMER_AUTO_OFFSET_RESET_CONFIG, AUTO_OFFSET_RESET_VALUE);
+        opts.put(KafkaSourceConnectorConfig.CONSUMER_GROUP_ID_CONFIG, CONSUMER_GROUP_ID_VALUE);
 
         config = new KafkaSourceConnectorConfig(opts);
         props = new Properties();
@@ -252,7 +254,7 @@ public class KafkaSourceTaskTest {
 
     @Test
     public void testStartSomeStoredPartitions() throws Exception {
-        opts.put(KafkaSourceConnectorConfig.TASK_LEADER_TOPIC_PARTITION_CONFIG, TASK_LEADER_TOPIC_PARTITION_CONFIG + "," + "0:" + SECOND_TOPIC + ":" + SECOND_PARTITION);
+        opts.put(KafkaSourceConnectorConfig.TASK_LEADER_TOPIC_PARTITION_CONFIG, TASK_LEADER_TOPIC_PARTITION_VALUE + "," + "0:" + SECOND_TOPIC + ":" + SECOND_PARTITION);
         config = new KafkaSourceConnectorConfig(opts);
         props = new Properties();
         props.putAll(config.allWithPrefix(KafkaSourceConnectorConfig.CONSUMER_PREFIX));
@@ -290,7 +292,7 @@ public class KafkaSourceTaskTest {
     @Test
     public void testPollNoRecords() throws Exception {
         mockConsumerInitialization();
-        EasyMock.expect(consumer.poll(5)).andReturn(new ConsumerRecords<>(Collections.EMPTY_MAP));
+        EasyMock.expect(consumer.poll(25)).andReturn(new ConsumerRecords<>(Collections.EMPTY_MAP));
         replayAll();
 
         objectUnderTest.start(opts);
@@ -305,7 +307,7 @@ public class KafkaSourceTaskTest {
     @Test
     public void testPollRecordReturnedNoIncludeHeaders() throws Exception {
         mockConsumerInitialization();
-        EasyMock.expect(consumer.poll(5)).andReturn(createTestRecords());
+        EasyMock.expect(consumer.poll(25)).andReturn(createTestRecords());
         replayAll();
 
         objectUnderTest.start(opts);
@@ -348,7 +350,7 @@ public class KafkaSourceTaskTest {
 
 
         // expectation for poll
-        EasyMock.expect(consumer.poll(5)).andReturn(createTestRecordsWithHeaders());
+        EasyMock.expect(consumer.poll(25)).andReturn(createTestRecordsWithHeaders());
         replayAll();
 
         objectUnderTest.start(opts);


### PR DESCRIPTION
- Update functionality and configs in like with [KIP-310](https://cwiki.apache.org/confluence/display/KAFKA/KIP-310%3A+Add+a+Kafka+Source+Connector+to+Kafka+Connect)
- Tidied up some logging statements.
- Bumped Kafka dependencies 2.0.0 (remove use of deprecated apis).