### PR TITLE
Use declared constants rather than string properties.

### DIFF
--- a/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorConfig.java
+++ b/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorConfig.java
@@ -10,6 +10,8 @@
 
 package com.comcast.kafka.connect.kafka;
 
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -17,6 +19,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.ValidString;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import java.util.*;
 import java.util.regex.Pattern;
@@ -89,33 +92,33 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
     public static final int MAX_SHUTDOWN_WAIT_MS_DEFAULT =      2000;
 
     // General Source Kafka Config - Applies to Consumer and Admin Client if not overridden by CONSUMER_PREFIX or ADMIN_CLIENT_PREFIX
-    public static final String SOURCE_BOOTSTRAP_SERVERS_CONFIG =          SOURCE_PREFIX.concat("bootstrap.servers");
+    public static final String SOURCE_BOOTSTRAP_SERVERS_CONFIG =          SOURCE_PREFIX.concat(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG);
     public static final String SOURCE_BOOTSTRAP_SERVERS_DOC =             "list of kafka brokers to use to bootstrap the source cluster";
     public static final Object SOURCE_BOOTSTRAP_SERVERS_DEFAULT =         ConfigDef.NO_DEFAULT_VALUE;
 
     // These are the kafka consumer configs we override defaults for
     // Note that *any* kafka consumer config can be set by adding the
     // CONSUMER_PREFIX in front of the standard consumer config strings
-    public static final String CONSUMER_MAX_POLL_RECORDS_CONFIG =           SOURCE_PREFIX.concat("max.poll.records");
+    public static final String CONSUMER_MAX_POLL_RECORDS_CONFIG =           SOURCE_PREFIX.concat(ConsumerConfig.MAX_POLL_RECORDS_CONFIG);
     public static final String CONSUMER_MAX_POLL_RECORDS_DOC =              "Maximum number of records to return from each poll of the consumer";
     public static final int CONSUMER_MAX_POLL_RECORDS_DEFAULT =             500;
-    public static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG =          SOURCE_PREFIX.concat("auto.offset.reset");
+    public static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG =          SOURCE_PREFIX.concat(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
     public static final String CONSUMER_AUTO_OFFSET_RESET_DOC =             "If there is no stored offset for a partition, where to reset from [earliest|latest].";
     public static final String CONSUMER_AUTO_OFFSET_RESET_DEFAULT =         "earliest";
     public static final ValidString CONSUMER_AUTO_OFFSET_RESET_VALIDATOR =  ConfigDef.ValidString.in("earliest", "latest");
-    public static final String CONSUMER_KEY_DESERIALIZER_CONFIG =           SOURCE_PREFIX.concat("key.deserializer");
+    public static final String CONSUMER_KEY_DESERIALIZER_CONFIG =           SOURCE_PREFIX.concat(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
     public static final String CONSUMER_KEY_DESERIALIZER_DOC =              "Key deserializer to use for the kafka consumers connecting to the source cluster.";
-    public static final String CONSUMER_KEY_DESERIALIZER_DEFAULT =          "org.apache.kafka.common.serialization.ByteArrayDeserializer";
-    public static final String CONSUMER_VALUE_DESERIALIZER_CONFIG =         SOURCE_PREFIX.concat("value.deserializer");
+    public static final String CONSUMER_KEY_DESERIALIZER_DEFAULT =          ByteArrayDeserializer.class.getName();
+    public static final String CONSUMER_VALUE_DESERIALIZER_CONFIG =         SOURCE_PREFIX.concat(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG);
     public static final String CONSUMER_VALUE_DESERIALIZER_DOC =            "Value deserializer to use for the kafka consumers connecting to the source cluster.";
-    public static final String CONSUMER_VALUE_DESERIALIZER_DEFAULT =        "org.apache.kafka.common.serialization.ByteArrayDeserializer";
-    public static final String CONSUMER_ENABLE_AUTO_COMMIT_CONFIG =         SOURCE_PREFIX.concat("enable.auto.commit");
+    public static final String CONSUMER_VALUE_DESERIALIZER_DEFAULT =        ByteArrayDeserializer.class.getName();
+    public static final String CONSUMER_ENABLE_AUTO_COMMIT_CONFIG =         SOURCE_PREFIX.concat(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
     public static final String CONSUMER_ENABLE_AUTO_COMMIT_DOC =            "If true the consumer's offset will be periodically committed to the source cluster in the background. "+
             "Note that these offsets are not used to resume the connector (They are stored in the Kafka Connect offset store), but may be useful in monitoring the current offset lag " +
             "of this connector on the source cluster";
     public static final Boolean CONSUMER_ENABLE_AUTO_COMMIT_DEFAULT =        true;
 
-    public static final String CONSUMER_GROUP_ID_CONFIG =         SOURCE_PREFIX.concat("group.id");
+    public static final String CONSUMER_GROUP_ID_CONFIG =         SOURCE_PREFIX.concat(ConsumerConfig.GROUP_ID_CONFIG);
     public static final String CONSUMER_GROUP_ID_DOC =            "Source Kafka Consumer group id. This must be set if source.enable.auto.commit is set as a group id is required for offset tracking on the source cluster";
     public static final Object CONSUMER_GROUP_ID_DEFAULT =        ConfigDef.NO_DEFAULT_VALUE;
 


### PR DESCRIPTION
Not sure about `max.poll.interval.ms` vs your `poll.loop.timeout.ms` & `session.timeout.ms` vs your `max.shutdown.wait.ms`, so left those alone. 

Also not added, but see [KAKFA-3073](https://issues.apache.org/jira/browse/KAFKA-3073) added the `topic.regex` property to `SinkTask` (but no reason why couldn't use the property name here even though this is a `SourceTask`). 

Also, [KAFKA-6890](https://issues.apache.org/jira/browse/KAFKA-6890) is one to watch. 