### PR TITLE
Add auto.offset.reset=none for using existing consumer group offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ Configuration Parameter | Example | Description
 ----------------------- | ------- | -----------
 **source.bootstrap.servers** | source.broker1:9092,source.broker2:9092 | **Mandatory.** Comma separated list of boostrap servers for the source Kafka cluster
 **source.topic.whitelist** | topic, topic-prefix* | Java regular expression to match topics to mirror. For convenience, comma (',') is interpreted as the regex-choice symbol ('|').
-**source.auto.offset.reset** | earliest | If there is no stored offset for a partition, indicates where to start consuming from. Options are _"earliest"_ or _"latest"_. Default: _earliest_
+**source.auto.offset.reset** | earliest | If there is no stored offset* for a partition, indicates where to start consuming from. Options are _"earliest"_,  _"latest"_, or _"none"_. Default: _earliest_
 **source.group.id** | kafka-connect | Group ID used when writing offsets back to source cluster (for offset lag tracking)
 **destination.topics.prefix** | aggregate. | Prefix to add to source topic names when determining the Kafka topic to publish data to
+
+* "*Stored offset*" here does not mean the stored consumer group offset, rather the stored offset within the Kafka Connect `offset.storage.topic` topic. If you want to start the connector from an existing consumer group, then set `source.auto.offset.reset` to `none`, and update `source.group.id` accordingly.
 
 ## Advanced Options
 
@@ -80,7 +82,7 @@ For cases where the configuration for the KafkaConsumer and AdminClient diverges
     "connector.class": "com.comcast.kafka.connect.kafka.KafkaSourceConnector", // The full class name of this connector
     "source.bootstrap.servers": "kafka.bootstrap.server1:9092,kafka.bootstrap.server2:9093", // Kafka boostrap servers for source cluster
     "source.topic.whitelist": "test.topic.*", // Mirror topics matching this regex
-    "source.auto.offset.reset": "earliest", // For partitions without existing offsets stored, start at the tail of the partition
+    "source.auto.offset.reset": "earliest", // For partitions without existing offsets stored, start at the head of the partition
     "source.group.id": "kafka-connect-testing", // Use this group ID when commiting offsets to the source cluster
     "destination.topics.prefix": "aggregate.", // Add "aggregate." as a prefix to the original topic name when sending to the destination cluster
     "connector.consumer.reconnect.backoff.max.ms": "10000" // Override the default consumer setting "reconnect.backoff.max.ms"

--- a/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorConfig.java
+++ b/src/main/java/com/comcast/kafka/connect/kafka/KafkaSourceConnectorConfig.java
@@ -12,6 +12,7 @@ package com.comcast.kafka.connect.kafka;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -107,9 +108,12 @@ public class KafkaSourceConnectorConfig extends AbstractConfig {
     public static final String CONSUMER_MAX_POLL_RECORDS_DOC =              "Maximum number of records to return from each poll of the consumer";
     public static final int CONSUMER_MAX_POLL_RECORDS_DEFAULT =             500;
     public static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG =          SOURCE_PREFIX.concat(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
-    public static final String CONSUMER_AUTO_OFFSET_RESET_DOC =             "If there is no stored offset for a partition, where to reset from [earliest|latest].";
+    public static final String CONSUMER_AUTO_OFFSET_RESET_DOC =             "If there is no stored offset for a partition, where to reset from [earliest|latest|none].";
     public static final String CONSUMER_AUTO_OFFSET_RESET_DEFAULT =         "earliest";
-    public static final ValidString CONSUMER_AUTO_OFFSET_RESET_VALIDATOR =  ConfigDef.ValidString.in("earliest", "latest");
+    public static final ValidString CONSUMER_AUTO_OFFSET_RESET_VALIDATOR =  ConfigDef.ValidString.in(
+                                                                                OffsetResetStrategy.EARLIEST.toString().toLowerCase(),
+                                                                                OffsetResetStrategy.LATEST.toString().toLowerCase(),
+                                                                                OffsetResetStrategy.NONE.toString().toLowerCase());
     public static final String CONSUMER_KEY_DESERIALIZER_CONFIG =           SOURCE_PREFIX.concat(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG);
     public static final String CONSUMER_KEY_DESERIALIZER_DOC =              "Key deserializer to use for the kafka consumers connecting to the source cluster.";
     public static final String CONSUMER_KEY_DESERIALIZER_DEFAULT =          ByteArrayDeserializer.class.getName();


### PR DESCRIPTION
`auto.offset.reset=earliest` and `source.group.id=<existing group>` doesn't do what I thought it would (starting from the offsets of an existing group).

Added `auto.offset.reset=none` to support this 

As in the docs

> - `none`: throw exception to the consumer if no previous offset is found for the consumer's group
> - anything else: throw exception to the consumer.